### PR TITLE
Update sirosen/texthooks ( 0.6.2 → 0.6.3 )

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: remove-crlf
       - id: remove-tabs
   - repo: https://github.com/sirosen/texthooks
-    rev: 0.6.2
+    rev: 0.6.3
     hooks:
       - id: fix-smartquotes
   - repo: https://github.com/k8s-at-home/sops-pre-commit


### PR DESCRIPTION
| datasource  | package           | from  | to    |
| ----------- | ----------------- | ----- | ----- |
| github-tags | sirosen/texthooks | 0.6.2 | 0.6.3 |