### PR TITLE
Ensure yaml-language-server stanzas for objects

### DIFF
--- a/cluster/apps/db/cloudnative-pg/cluster/podmonitor.yaml
+++ b/cluster/apps/db/cloudnative-pg/cluster/podmonitor.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/cluster/apps/db/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/cluster/apps/db/cloudnative-pg/cluster/prometheusrule.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/cluster/apps/db/namespace.yaml
+++ b/cluster/apps/db/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/default/homepage/app/configmap.yaml
+++ b/cluster/apps/default/homepage/app/configmap.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/apps/default/homepage/app/rbac.yaml
+++ b/cluster/apps/default/homepage/app/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/clusterrole.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -36,6 +37,7 @@ rules:
     verbs:
       - get
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/clusterrolebinding.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/cluster/apps/default/namespace.yaml
+++ b/cluster/apps/default/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/disk/namespace.yaml
+++ b/cluster/apps/disk/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/kube-system/amd-gpu/ks.yaml
+++ b/cluster/apps/kube-system/amd-gpu/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/kube-system/konnectivity-agent/konnectivity-agent.yaml
+++ b/cluster/apps/kube-system/konnectivity-agent/konnectivity-agent.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/daemonset.json
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/cluster/apps/kube-system/namespace.yaml
+++ b/cluster/apps/kube-system/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/kube-system/reloader/ks.yaml
+++ b/cluster/apps/kube-system/reloader/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/kube-system/replicator/ks.yaml
+++ b/cluster/apps/kube-system/replicator/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/media/kyoo/app/config.yaml
+++ b/cluster/apps/media/kyoo/app/config.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/apps/media/kyoo/ks.yaml
+++ b/cluster/apps/media/kyoo/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/media/namespace.yaml
+++ b/cluster/apps/media/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/media/pvc/pvc.yaml
+++ b/cluster/apps/media/pvc/pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/cluster/apps/media/rutorrent/ks.yaml
+++ b/cluster/apps/media/rutorrent/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/cert-manager/certs/defaultcert.yaml
+++ b/cluster/apps/net/cert-manager/certs/defaultcert.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/crd-certificates.yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/cluster/apps/net/cert-manager/issuers/clusterissuer.yaml
+++ b/cluster/apps/net/cert-manager/issuers/clusterissuer.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cert-manager/cert-manager/master/deploy/crds/crd-clusterissuers.yaml
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/cluster/apps/net/cilium/config/ciliumbgppeeringpolicy.yaml
+++ b/cluster/apps/net/cilium/config/ciliumbgppeeringpolicy.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/cilium/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumBGPPeeringPolicy
 metadata:

--- a/cluster/apps/net/cilium/config/ciliumloadbalancerippool.yaml
+++ b/cluster/apps/net/cilium/config/ciliumloadbalancerippool.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/cilium/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:

--- a/cluster/apps/net/kustomization.yaml
+++ b/cluster/apps/net/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/net/namespace.yaml
+++ b/cluster/apps/net/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/o11y/coroot/ks.yaml
+++ b/cluster/apps/o11y/coroot/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/flux-webui/ks.yaml
+++ b/cluster/apps/o11y/flux-webui/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/goldpinger/ks.yaml
+++ b/cluster/apps/o11y/goldpinger/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/grafana/ks.yaml
+++ b/cluster/apps/o11y/grafana/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/metrics-server/ks.yaml
+++ b/cluster/apps/o11y/metrics-server/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/namespace.yaml
+++ b/cluster/apps/o11y/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/o11y/smartctl-exporter/app/scrape.yaml
+++ b/cluster/apps/o11y/smartctl-exporter/app/scrape.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:

--- a/cluster/apps/o11y/smartctl-exporter/ks.yaml
+++ b/cluster/apps/o11y/smartctl-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/victoria-logs/ks.yaml
+++ b/cluster/apps/o11y/victoria-logs/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/victoria-metrics/app/flux.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/flux.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/cluster/apps/o11y/victoria-metrics/app/k0s.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/k0s.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/cluster/apps/o11y/victoria-metrics/app/kustomization.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/victoria-metrics/app/pg-agent.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/pg-agent.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/VictoriaMetrics/operator/master/config/crd/bases/operator.victoriametrics.com_vmpodscrapes.yaml
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:

--- a/cluster/apps/o11y/victoria-metrics/ks.yaml
+++ b/cluster/apps/o11y/victoria-metrics/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/kustomization.yaml
+++ b/cluster/apps/selfhosted/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/selfhosted/namespace.yaml
+++ b/cluster/apps/selfhosted/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/apps/selfhosted/ollama/app/kustomization.yaml
+++ b/cluster/apps/selfhosted/ollama/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/selfhosted/open-webui/app/kustomization.yaml
+++ b/cluster/apps/selfhosted/open-webui/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/flux/config/cluster.yaml
+++ b/cluster/flux/config/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -17,6 +18,7 @@ spec:
     # include kubernetes directory
     !/cluster
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/flux/config/flux.yaml
+++ b/cluster/flux/config/flux.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -10,6 +11,7 @@ spec:
   ref:
     tag: v2.6.4
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/flux/repositories/helm/amd-gpu.yaml
+++ b/cluster/flux/repositories/helm/amd-gpu.yaml
@@ -1,8 +1,9 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: amd
+  name: amd-gpu
   namespace: flux-system
 spec:
   interval: 1h

--- a/cluster/flux/repositories/helm/bjw-s.yaml
+++ b/cluster/flux/repositories/helm/bjw-s.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/certmanager.yaml
+++ b/cluster/flux/repositories/helm/certmanager.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/cloudnative-pg.yaml
+++ b/cluster/flux/repositories/helm/cloudnative-pg.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/external-dns.yaml
+++ b/cluster/flux/repositories/helm/external-dns.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/goldpinger.yaml
+++ b/cluster/flux/repositories/helm/goldpinger.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/ha.yaml
+++ b/cluster/flux/repositories/helm/ha.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/homepage.yaml
+++ b/cluster/flux/repositories/helm/homepage.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/intel.yaml
+++ b/cluster/flux/repositories/helm/intel.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/kyoo.yaml
+++ b/cluster/flux/repositories/helm/kyoo.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/cluster/flux/repositories/helm/metrics-server.yaml
+++ b/cluster/flux/repositories/helm/metrics-server.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/node-feature-discovery.yaml
+++ b/cluster/flux/repositories/helm/node-feature-discovery.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/pixie.yaml
+++ b/cluster/flux/repositories/helm/pixie.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/prometheus.yaml
+++ b/cluster/flux/repositories/helm/prometheus.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/reloader.yaml
+++ b/cluster/flux/repositories/helm/reloader.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/replicator.yaml
+++ b/cluster/flux/repositories/helm/replicator.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/victoriametrics.yaml
+++ b/cluster/flux/repositories/helm/victoriametrics.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/vars/cluster-settings.yaml
+++ b/cluster/flux/vars/cluster-settings.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Add `yaml-language-server` stanzas to YAML files for schema validation and autocompletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-e765bda5-22f3-4cd9-910f-b0c0921827e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e765bda5-22f3-4cd9-910f-b0c0921827e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

