### PR TITLE
Ensure yaml files have language server stanzas

### DIFF
--- a/.schemas/any.json
+++ b/.schemas/any.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Any value",
+  "description": "Permissive schema used for non-Kubernetes YAML or SOPS-encrypted resources.",
+  "oneOf": [
+    {"type": "object"},
+    {"type": "array"},
+    {"type": "string"},
+    {"type": "number"},
+    {"type": "boolean"},
+    {"type": "null"}
+  ]
+}

--- a/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json=https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json=https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/cluster/apps/db/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/cluster/apps/db/cloudnative-pg/ks.yaml
+++ b/cluster/apps/db/cloudnative-pg/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/db/cloudnative-pg/ks.yaml
+++ b/cluster/apps/db/cloudnative-pg/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/db/cloudnative-pg/ks.yaml
+++ b/cluster/apps/db/cloudnative-pg/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/db/kustomization.yaml
+++ b/cluster/apps/db/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/db/kustomization.yaml
+++ b/cluster/apps/db/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/db/kustomization.yaml
+++ b/cluster/apps/db/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/default/homepage/ks.yaml
+++ b/cluster/apps/default/homepage/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/default/homepage/ks.yaml
+++ b/cluster/apps/default/homepage/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/default/homepage/ks.yaml
+++ b/cluster/apps/default/homepage/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/default/whoami/app/kustomization.yaml
+++ b/cluster/apps/default/whoami/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/default/whoami/app/kustomization.yaml
+++ b/cluster/apps/default/whoami/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/default/whoami/app/kustomization.yaml
+++ b/cluster/apps/default/whoami/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/default/whoami/ks.yaml
+++ b/cluster/apps/default/whoami/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/default/whoami/ks.yaml
+++ b/cluster/apps/default/whoami/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/default/whoami/ks.yaml
+++ b/cluster/apps/default/whoami/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/democratic-csi/ks.yaml
+++ b/cluster/apps/disk/democratic-csi/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/democratic-csi/ks.yaml
+++ b/cluster/apps/disk/democratic-csi/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/democratic-csi/ks.yaml
+++ b/cluster/apps/disk/democratic-csi/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/kustomization.yaml
+++ b/cluster/apps/disk/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/kustomization.yaml
+++ b/cluster/apps/disk/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/kustomization.yaml
+++ b/cluster/apps/disk/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
+++ b/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
+++ b/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
+++ b/cluster/apps/disk/snapshot-controller/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/disk/snapshot-controller/ks.yaml
+++ b/cluster/apps/disk/snapshot-controller/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/snapshot-controller/ks.yaml
+++ b/cluster/apps/disk/snapshot-controller/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/disk/snapshot-controller/ks.yaml
+++ b/cluster/apps/disk/snapshot-controller/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
+++ b/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
+++ b/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
+++ b/cluster/apps/kube-system/amd-gpu/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/reloader/app/kustomization.yaml
+++ b/cluster/apps/kube-system/reloader/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/reloader/app/kustomization.yaml
+++ b/cluster/apps/kube-system/reloader/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/reloader/app/kustomization.yaml
+++ b/cluster/apps/kube-system/reloader/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/replicator/app/kustomization.yaml
+++ b/cluster/apps/kube-system/replicator/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/replicator/app/kustomization.yaml
+++ b/cluster/apps/kube-system/replicator/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/kube-system/replicator/app/kustomization.yaml
+++ b/cluster/apps/kube-system/replicator/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/net/cilium/config/kustomization.yaml
+++ b/cluster/apps/net/cilium/config/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: net

--- a/cluster/apps/net/cilium/config/kustomization.yaml
+++ b/cluster/apps/net/cilium/config/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: net

--- a/cluster/apps/net/cilium/config/kustomization.yaml
+++ b/cluster/apps/net/cilium/config/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: net

--- a/cluster/apps/net/cilium/ks.yaml
+++ b/cluster/apps/net/cilium/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/cilium/ks.yaml
+++ b/cluster/apps/net/cilium/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/cilium/ks.yaml
+++ b/cluster/apps/net/cilium/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/ingress-nginx/ks.yaml
+++ b/cluster/apps/net/ingress-nginx/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/ingress-nginx/ks.yaml
+++ b/cluster/apps/net/ingress-nginx/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/net/ingress-nginx/ks.yaml
+++ b/cluster/apps/net/ingress-nginx/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/o11y/coroot/app/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/coroot/app/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/coroot/app/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/coroot/operator/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/operator/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/coroot/operator/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/operator/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/coroot/operator/kustomization.yaml
+++ b/cluster/apps/o11y/coroot/operator/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/flux-webui/app/kustomization.yaml
+++ b/cluster/apps/o11y/flux-webui/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/flux-webui/app/kustomization.yaml
+++ b/cluster/apps/o11y/flux-webui/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/flux-webui/app/kustomization.yaml
+++ b/cluster/apps/o11y/flux-webui/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/goldpinger/app/kustomization.yaml
+++ b/cluster/apps/o11y/goldpinger/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/goldpinger/app/kustomization.yaml
+++ b/cluster/apps/o11y/goldpinger/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/goldpinger/app/kustomization.yaml
+++ b/cluster/apps/o11y/goldpinger/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/grafana/app/kustomization.yaml
+++ b/cluster/apps/o11y/grafana/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/grafana/app/kustomization.yaml
+++ b/cluster/apps/o11y/grafana/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/grafana/app/kustomization.yaml
+++ b/cluster/apps/o11y/grafana/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/kustomization.yaml
+++ b/cluster/apps/o11y/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/kustomization.yaml
+++ b/cluster/apps/o11y/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/kustomization.yaml
+++ b/cluster/apps/o11y/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/metrics-server/app/kustomization.yaml
+++ b/cluster/apps/o11y/metrics-server/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/metrics-server/app/kustomization.yaml
+++ b/cluster/apps/o11y/metrics-server/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/metrics-server/app/kustomization.yaml
+++ b/cluster/apps/o11y/metrics-server/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
+++ b/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
+++ b/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
+++ b/cluster/apps/o11y/smartctl-exporter/app/nas.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
+++ b/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
+++ b/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
+++ b/cluster/apps/o11y/victoria-logs/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/apps/selfhosted/ollama/ks.yaml
+++ b/cluster/apps/selfhosted/ollama/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/ollama/ks.yaml
+++ b/cluster/apps/selfhosted/ollama/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/ollama/ks.yaml
+++ b/cluster/apps/selfhosted/ollama/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/open-webui/ks.yaml
+++ b/cluster/apps/selfhosted/open-webui/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/open-webui/ks.yaml
+++ b/cluster/apps/selfhosted/open-webui/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/open-webui/ks.yaml
+++ b/cluster/apps/selfhosted/open-webui/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/perplexica/ks.yaml
+++ b/cluster/apps/selfhosted/perplexica/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/perplexica/ks.yaml
+++ b/cluster/apps/selfhosted/perplexica/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/perplexica/ks.yaml
+++ b/cluster/apps/selfhosted/perplexica/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/searxng/app/settings.yml
+++ b/cluster/apps/selfhosted/searxng/app/settings.yml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=../../../../.schemas/any.json
 general:
   # Debug mode, only for development. Is overwritten by ${SEARXNG_DEBUG}
   debug: false

--- a/cluster/apps/selfhosted/searxng/ks.yaml
+++ b/cluster/apps/selfhosted/searxng/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/searxng/ks.yaml
+++ b/cluster/apps/selfhosted/searxng/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/apps/selfhosted/searxng/ks.yaml
+++ b/cluster/apps/selfhosted/searxng/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/bootstrap/flux/age-key.sops.yaml
+++ b/cluster/bootstrap/flux/age-key.sops.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../.schemas/any.json
 apiVersion: v1
 data:
     age.agekey: ENC[AES256_GCM,data:+/fU63GEXinpgJbFFwttJlQT1jF1pEshtnb0mVT52hVDGtD6EDyB0DDDQ97M5+ROj2X+ImA+EuF6g5fZO0rmdZj6fht8kXGW6KKIFeeZLan+xPf4nhI/0DYGVZIVxOlSwlzWfYi3I1JrYE9UdZSHl9FjSHi5UBAM/V2BTY1CKkFkudUb+4je/zlfddRW8+GIoOFjGFrPdn/tVCo6yIdKYqGRiS8okVBPTIcpTvsFi46PvwE2LHvwgQTUFahyeHHb4W2mFq4nW5t4RHsrUMdA7M/f3dGf5UABvwewTgDoOD1lwrp94vpod84KHsDTsHD5GTJwVwxG4ytCJBtf,iv:mWIv5OmZo25w7KrGckQhaAU0wi+CIh9PFyuIK5/0NCM=,tag:Uf8wClxQVuFbPAXF1x4Wgg==,type:str]

--- a/cluster/bootstrap/flux/github-deploy-key.sops.yaml
+++ b/cluster/bootstrap/flux/github-deploy-key.sops.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../.schemas/any.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/cluster/flux/apps.yaml
+++ b/cluster/flux/apps.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/flux/apps.yaml
+++ b/cluster/flux/apps.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/flux/apps.yaml
+++ b/cluster/flux/apps.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/cluster/flux/repositories/git/local-path-provisioner.yaml
+++ b/cluster/flux/repositories/git/local-path-provisioner.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/cluster/flux/repositories/git/local-path-provisioner.yaml
+++ b/cluster/flux/repositories/git/local-path-provisioner.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/cluster/flux/repositories/git/local-path-provisioner.yaml
+++ b/cluster/flux/repositories/git/local-path-provisioner.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/gitrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:

--- a/cluster/flux/repositories/helm/bitnami.yaml
+++ b/cluster/flux/repositories/helm/bitnami.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/bitnami.yaml
+++ b/cluster/flux/repositories/helm/bitnami.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/bitnami.yaml
+++ b/cluster/flux/repositories/helm/bitnami.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/coroot.yaml
+++ b/cluster/flux/repositories/helm/coroot.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/coroot.yaml
+++ b/cluster/flux/repositories/helm/coroot.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/coroot.yaml
+++ b/cluster/flux/repositories/helm/coroot.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/democratic-csi.yaml
+++ b/cluster/flux/repositories/helm/democratic-csi.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/democratic-csi.yaml
+++ b/cluster/flux/repositories/helm/democratic-csi.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/democratic-csi.yaml
+++ b/cluster/flux/repositories/helm/democratic-csi.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/gadget.yaml
+++ b/cluster/flux/repositories/helm/gadget.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/gadget.yaml
+++ b/cluster/flux/repositories/helm/gadget.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/gadget.yaml
+++ b/cluster/flux/repositories/helm/gadget.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/grafana.yaml
+++ b/cluster/flux/repositories/helm/grafana.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/grafana.yaml
+++ b/cluster/flux/repositories/helm/grafana.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/grafana.yaml
+++ b/cluster/flux/repositories/helm/grafana.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/ingress-nginx.yaml
+++ b/cluster/flux/repositories/helm/ingress-nginx.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/ingress-nginx.yaml
+++ b/cluster/flux/repositories/helm/ingress-nginx.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/ingress-nginx.yaml
+++ b/cluster/flux/repositories/helm/ingress-nginx.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/kustomization.yaml
+++ b/cluster/flux/repositories/helm/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/flux/repositories/helm/kustomization.yaml
+++ b/cluster/flux/repositories/helm/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/flux/repositories/helm/kustomization.yaml
+++ b/cluster/flux/repositories/helm/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://json.schemastore.org/kustomization=https://json.schemastore.org/kustomization
+# yaml-language-server: =https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/cluster/flux/repositories/helm/metallb.yaml
+++ b/cluster/flux/repositories/helm/metallb.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/metallb.yaml
+++ b/cluster/flux/repositories/helm/metallb.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/metallb.yaml
+++ b/cluster/flux/repositories/helm/metallb.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/pgadmin.yaml
+++ b/cluster/flux/repositories/helm/pgadmin.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/pgadmin.yaml
+++ b/cluster/flux/repositories/helm/pgadmin.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/pgadmin.yaml
+++ b/cluster/flux/repositories/helm/pgadmin.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/snapshotter.yaml
+++ b/cluster/flux/repositories/helm/snapshotter.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/snapshotter.yaml
+++ b/cluster/flux/repositories/helm/snapshotter.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/snapshotter.yaml
+++ b/cluster/flux/repositories/helm/snapshotter.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/weaveworks.yaml
+++ b/cluster/flux/repositories/helm/weaveworks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/weaveworks.yaml
+++ b/cluster/flux/repositories/helm/weaveworks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/repositories/helm/weaveworks.yaml
+++ b/cluster/flux/repositories/helm/weaveworks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: =https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/source.toolkit.fluxcd.io/helmrepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:

--- a/cluster/flux/vars/cluster-secrets.sops.yaml
+++ b/cluster/flux/vars/cluster-secrets.sops.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../.schemas/any.json
 apiVersion: v1
 stringData:
     SECRET_DOMAIN: ENC[AES256_GCM,data:EGf0Cc8=,iv:lRn81tg8r802YdQz96BpljBVsf13vXJBEmTnKBN9Cls=,tag:xb4scMvCcPM+JGVmY6AARQ==,type:str]

--- a/cluster/flux/vars/kustomization.yaml
+++ b/cluster/flux/vars/kustomization.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Add `yaml-language-server` modelines to all YAML files to enable schema validation and auto-completion.

Modelines point to specific schemas for Kubernetes resources (Kustomization, Flux, Helm, CNPG) and a new permissive local schema (`.schemas/any.json`) for generic YAML and SOPS-encrypted files.

---
<a href="https://cursor.com/background-agent?bcId=bc-6934f360-b394-4f8d-bedf-ff18c503c50f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6934f360-b394-4f8d-bedf-ff18c503c50f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

