### PR TITLE
fix(homepage): mount SA token for cluster-mode widgets

### DIFF
--- a/cluster/apps/default/homepage/app/helmrelease.yaml
+++ b/cluster/apps/default/homepage/app/helmrelease.yaml
@@ -17,6 +17,10 @@ spec:
         annotations:
           configmap.reloader.stakater.com/reload: &configmap homepage
         strategy: RollingUpdate
+        pod:
+          # app-template v5 defaults this to false; homepage cluster-mode widgets
+          # need the SA token mounted to read nodes/ingresses in-cluster
+          automountServiceAccountToken: true
         containers:
           main:
             image:


### PR DESCRIPTION
## Problem

Homepage's kubernetes `mode: cluster` widgets (node stats, ingress autodiscovery) were erroring on every refresh:

```
error: <widget> Error getting nodes: NaN undefined undefined
Error: ENOENT: no such file or directory, open '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
```

## Cause

app-template **v4.6.2 → v5.0.0** (2026-05-08) flipped the common-library default `pod.automountServiceAccountToken` to `false` (security hardening, per CIS 5.1.6). Homepage legitimately needs the in-cluster SA token to read nodes/ingresses, so the token simply stopped being mounted.

## Fix

Re-enable automount for this workload only. The dedicated `homepage` SA already carries a least-privilege read-only ClusterRole, so blast radius is unchanged.