### PR TITLE
fix(victoria-metrics): raise vm-operator memory limit to 256Mi

### DIFF
--- a/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
@@ -55,10 +55,10 @@ spec:
       resources:
         requests:
           cpu: 20m
-          memory: 100Mi
+          memory: 150Mi
           ephemeral-storage: 100Mi
         limits:
-          memory: 150Mi
+          memory: 256Mi
           ephemeral-storage: 500Mi
       operator:
         disable_prometheus_converter: false


### PR DESCRIPTION
## Symptom

Two alerts firing for job `vmagent-vm`:
- **TooManyScrapeErrors** — vmagent fails to scrape one or more targets for 15m
- **TooManyLogs** — vmagent emits >15 warn logs / 5m

## Root cause

Both have a single cause: vmagent cannot scrape **vm-operator** (`10.244.1.19:8080/metrics`). Every scrape times out *awaiting headers*:

```
cannot scrape target ".../metrics" (job="vm-operator") ... Client.Timeout exceeded while awaiting headers
```

The operator pod sits at **146Mi against a 150Mi memory limit** (0 restarts, CPU idle at 5m). It's not OOMKilled, but Go GC thrash right at the heap ceiling stalls the `/metrics` HTTP handler past the scrape timeout. A `wget` of the endpoint from inside the cluster also times out. The one warn-per-failed-scrape (~every 20s) is exactly what trips both alerts.

## Fix

Give the operator headroom: request `100Mi -> 150Mi`, limit `150Mi -> 256Mi`. Unrelated to #989.