### PR TITLE
fix(victoria-metrics): upgrade k8s-stack to 0.84.0 — fix operator metrics deadlock

### DIFF
--- a/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     spec:
       chart: victoria-metrics-k8s-stack
-      version: 0.83.0
+      version: 0.84.0
       sourceRef:
         kind: HelmRepository
         name: victoriametrics
@@ -55,10 +55,10 @@ spec:
       resources:
         requests:
           cpu: 20m
-          memory: 150Mi
+          memory: 100Mi
           ephemeral-storage: 100Mi
         limits:
-          memory: 256Mi
+          memory: 150Mi
           ephemeral-storage: 500Mi
       operator:
         disable_prometheus_converter: false


### PR DESCRIPTION
## The recurring alerts are back, and the memory bump (#990) did NOT fix them

Same `TooManyScrapeErrors` + `TooManyLogs` for `vmagent-vm`, same single failing target: the **vm-operator** `/metrics` endpoint times out awaiting headers.

## Real root cause

This is **not** a resource problem — the operator sits at **51Mi / 256Mi**, idle CPU, 0 restarts. The `/metrics` HTTP handler itself hangs (>10s, no response) while the probe endpoint stays healthy (so the pod never restarts).

operator **v0.71.0** has a deadlock in the `operator_object_status` metrics collector once tracked objects exceed 250: `Collect()` holds a mutex while sending to the prometheus channel, which deadlocks the metrics server. Symptoms match exactly — works right after restart, wedges after hours as objects accumulate.

Fixed upstream in operator **v0.72.0**.

## Fix

Bump `victoria-metrics-k8s-stack` `0.83.0 -> 0.84.0`, which pulls operator subchart `0.65.0` = app **v0.72.0**.

Also **revert the 150->256Mi memory bump from #990** — that was a misdiagnosis. The operator runs fine at ~51Mi; the pod *restart* from that rollout is what masked the deadlock for ~17h, not the extra RAM.