### PR TITLE
fix(victoria-metrics): pull operator image from quay.io

### DIFF
--- a/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
@@ -30,6 +30,12 @@ spec:
   values:
     victoria-metrics-operator:
       nameOverride: operator
+      # Pull the operator from quay.io instead of the chart default (docker.io).
+      # Fresh anonymous pulls of new tags from registry-1.docker.io intermittently
+      # time out / hit rate limits here, which failed the 0.84.0 helm upgrade
+      # (operator v0.72.0 image) and rolled it back. quay.io mirrors the same image.
+      image:
+        registry: quay.io
       crds:
         cleanup:
           image:


### PR DESCRIPTION
## Why the alert didn't clear after #991

#991 merged, but the cluster never ran v0.72.0. The helm upgrade to k8s-stack 0.84.0 **failed and rolled back**:

```
UpgradeFailed: ... failed early due to stalled resources:
  [Deployment/o11y/vm-operator status: 'Failed']
```

Root cause = **ImagePullBackOff** on the new operator image:
```
Failed to pull "docker.io/victoriametrics/operator:v0.72.0":
  dial tcp registry-1.docker.io:443: i/o timeout
```

docker.io is *reachable* from the cluster (verified, 401) but flaky/rate-limited for **fresh anonymous pulls of uncached tags** — every other image was already cached, so only the brand-new v0.72.0 tag failed. Flux then rolled back to 0.83.0, leaving the deadlocked **v0.71.0** operator running → alerts kept firing.

## Fix

Override `victoria-metrics-operator.image.registry: quay.io`. VictoriaMetrics mirrors the operator there (`quay.io/victoriametrics/operator:v0.72.0` → 200, pulls cleanly, no rate limit).

## Verified live

Patched the running deployment to the quay image:
- ✅ rolled out, **v0.72.0 Running**
- ✅ `/metrics` responds in 0.00s (deadlock gone)
- ✅ 0 vm-operator scrape errors since
- operator sits at ~49Mi (150Mi limit is fine)

After merge, Flux retries the stalled HelmRelease with the quay override and adopts the already-running pod. Depends on / follows #991.