### PR TITLE
chore(renovate): let observability charts update at any time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,5 +87,15 @@
       ],
       prConcurrentLimit: 1,
     },
+    {
+      // Observability stack (o11y namespace) updates at any time instead of
+      // waiting for the Mon/Wed/Fri-before-6am window. Bugfix/security releases
+      // here (e.g. the vm-operator metrics deadlock) should land fast, not sit
+      // for up to ~2 days. Scoped by path so it covers every chart under o11y
+      // regardless of datasource/package-name quirks.
+      description: "Observability charts: update at any time",
+      matchFileNames: ["cluster/apps/o11y/**"],
+      schedule: ["at any time"],
+    },
   ],
 }


### PR DESCRIPTION
## Why

The vm-operator metrics-deadlock fix (operator v0.72.0 / k8s-stack 0.84.0) was **detected** by renovate but held for up to ~2 days because the global schedule only opens PRs `before 6am on Mon/Wed/Fri`, and 0.84.0 landed just after a window. The bugfix sat queued while the alert fired.

## Change

Add a packageRule giving everything under `cluster/apps/o11y/**` `schedule: ["at any time"]`, overriding the global window so observability bugfix/security releases land on the next 6-hourly renovate run.

Scoped **by path**, not by the existing "Observability group" package names — those (`victoriametrics/victoria-metrics` etc.) don't match the `victoria-metrics-k8s-stack` chart's renovate package name, so a group-based schedule wouldn't have covered the chart that caused this.