### PR TITLE
fix(netbox): raise memory limit to 2Gi to stop OOMKills

### DIFF
--- a/cluster/apps/net/netbox/app/helmrelease.yaml
+++ b/cluster/apps/net/netbox/app/helmrelease.yaml
@@ -144,9 +144,9 @@ spec:
     resources:
       requests:
         cpu: 250m
-        memory: 512Mi
-      limits:
         memory: 1Gi
+      limits:
+        memory: 2Gi
 
     # -- Background worker
     worker:


### PR DESCRIPTION
## Problem

netbox was **OOMKilled** today (exit 137, 12:24) at its 1Gi memory limit and immediately climbed back to **976Mi / 1Gi** — so it would keep OOMing. Found during a cluster-wide log/health sweep.

## Fix

Bump the netbox container resources (`cluster/apps/net/netbox/app/helmrelease.yaml`):
- request `512Mi -> 1Gi`
- limit `1Gi -> 2Gi`

Django/gunicorn baseline footprint here is ~1Gi, so this gives real headroom instead of running flush against the ceiling.