### PR TITLE
fix(victoria-metrics): disable false-positive CM/scheduler alert rules

### DIFF
--- a/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
@@ -74,6 +74,17 @@ spec:
     coreDns:
       spec:
         jobLabel: "jobLabel"
+    # We don't scrape kube-controller-manager / kube-scheduler (enabled: false
+    # below), so the matching default alert/recording rule groups can only ever
+    # fire false KubeControllerManagerDown / KubeSchedulerDown alerts. Disable them.
+    defaultRules:
+      groups:
+        kubernetesSystemControllerManager:
+          enabled: false   # KubeControllerManagerDown
+        kubernetesSystemScheduler:
+          enabled: false   # KubeSchedulerDown
+        kubeScheduler:
+          enabled: false   # kube-scheduler recording rules
     kubeControllerManager:
       enabled: false
     kubeEtcd:


### PR DESCRIPTION
## Problem

`KubeControllerManagerDown` and `KubeSchedulerDown` critical alerts have been firing since the `victoria-metrics-k8s-stack` 0.84.0 bump (~12h ago), even though the control plane is fully healthy.

Root cause is a config mismatch: we have `kubeControllerManager.enabled: false` and `kubeScheduler.enabled: false` (no scrape target / VMServiceScrape is created), but the chart's default alert rule groups are enabled. Those rules use `absent(up{job=...})`, so with no `up{}` series they fire permanently as false positives.

## Fix

Disable the matching default rule groups to align with the fact that we don't scrape these components:

- `kubernetesSystemControllerManager` → `KubeControllerManagerDown`
- `kubernetesSystemScheduler` → `KubeSchedulerDown`
- `kubeScheduler` → kube-scheduler recording rules

## Verify

After Flux reconciles:

```
kubectl get vmrule -n o11y | grep -Ei 'controller|scheduler'   # should return nothing
```