### PR TITLE
feat(net): deploy rackpad via app-template

### DIFF
--- a/cluster/apps/net/kustomization.yaml
+++ b/cluster/apps/net/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./external-dns/ks.yaml
   - ./ingress-nginx/ks.yaml
   - ./netbox/ks.yaml
+  - ./rackpad/ks.yaml

--- a/cluster/apps/net/rackpad/app/helmrelease.yaml
+++ b/cluster/apps/net/rackpad/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rackpad
+  namespace: net
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      main:
+        type: deployment
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/kobii-git/rackpad
+              tag: v1.6.5
+            env:
+              TZ: ${TIMEZONE}
+              PORT: &port 3000
+              DATABASE_PATH: /data/rackpad.db
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+    ingress:
+      main:
+        className: private
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+        hosts:
+          - host: &host rackpad.${SECRET_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: main
+                  port: *port
+        tls:
+          - secretName: rackpad-tls
+            hosts:
+              - *host
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        size: 2Gi
+        storageClass: nasty-iscsi
+        accessMode: ReadWriteOnce
+        retain: true
+        globalMounts:
+          - path: /data

--- a/cluster/apps/net/rackpad/app/kustomization.yaml
+++ b/cluster/apps/net/rackpad/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/cluster/apps/net/rackpad/ks.yaml
+++ b/cluster/apps/net/rackpad/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rackpad
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/net/rackpad/app
+  sourceRef:
+    kind: GitRepository
+    name: homelab
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: &appname rackpad
+  prune: true
+  wait: false
+  interval: 10m
+  dependsOn:
+    - name: ingress-nginx
+    - name: nasty-csi


### PR DESCRIPTION
Deploys [rackpad](https://github.com/Kobii-git/rackpad) (rack/IPAM inventory) in the `net` namespace using the bjw-s `app-template` chart.

- **Image:** `ghcr.io/kobii-git/rackpad:v1.6.5`
- **Storage:** PVC at `/data` on `nasty-iscsi` (block storage — SQLite/better-sqlite3 needs reliable file locking, avoided NFS)
- **SecurityContext:** runs as uid/gid 10001 (image's `rackpad` user)
- **Ingress:** `private` class, `rackpad.${SECRET_DOMAIN}`, letsencrypt-production
- `dependsOn`: ingress-nginx, nasty-csi