### PR TITLE
fix(net): correct rackpad image tag (no v prefix)

### DIFF
--- a/cluster/apps/net/rackpad/app/helmrelease.yaml
+++ b/cluster/apps/net/rackpad/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           main:
             image:
               repository: ghcr.io/kobii-git/rackpad
-              tag: v1.6.5
+              tag: 1.6.5
             env:
               TZ: ${TIMEZONE}
               PORT: &port 3000


### PR DESCRIPTION
GHCR publishes rackpad as `1.6.5`, not `v1.6.5` (the git tags use a `v` prefix but the container tags don't). This was causing `ImagePullBackOff`. Storage/scheduling were fine.