### PR TITLE
feat(net): enable rackpad discovery scans (NET_RAW + SNMP)

### DIFF
--- a/cluster/apps/net/rackpad/app/helmrelease.yaml
+++ b/cluster/apps/net/rackpad/app/helmrelease.yaml
@@ -23,11 +23,14 @@ spec:
     keepHistory: false
   values:
     defaultPodOptions:
+      # Run as root so the explicitly-granted NET_RAW / NET_BIND_SERVICE caps
+      # are effective (k8s can't grant ambient caps to a non-root uid). The
+      # container still drops every other capability below. Discovery needs
+      # raw sockets for ICMP/TCP scans and to bind the SNMP trap listener.
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10001
-        fsGroup: 10001
-        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
     controllers:
       main:
         type: deployment
@@ -38,6 +41,14 @@ spec:
             image:
               repository: ghcr.io/kobii-git/rackpad
               tag: 1.6.5
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                  - NET_RAW          # raw sockets for ICMP / TCP discovery scans
+                  - NET_BIND_SERVICE # bind the SNMP trap listener on a low port
+                drop:
+                  - ALL
             env:
               TZ: ${TIMEZONE}
               PORT: &port 3000


### PR DESCRIPTION
Tier-1 discovery enablement for rackpad.

Runs the pod as root but **drops ALL capabilities except**:
- `NET_RAW` — raw sockets for ICMP / TCP reachability scans
- `NET_BIND_SERVICE` — bind the SNMP trap listener on a low port

`allowPrivilegeEscalation: false` is kept. The `net` namespace already enforces pod-security `privileged`, so this is permitted.

**Scope:** L3 reachability + full SNMP discovery/sync (works across all VLANs via switch bridge tables). **Not included:** L2/ARP MAC capture, which would need `hostNetwork: true` + `NET_ADMIN` and only reaches the nodes' own subnet — deferred until we confirm VLAN layout.