### PR TITLE
fix(net): use /api/health for rackpad probes

### DIFF
--- a/cluster/apps/net/rackpad/app/helmrelease.yaml
+++ b/cluster/apps/net/rackpad/app/helmrelease.yaml
@@ -56,11 +56,30 @@ spec:
             probes:
               liveness:
                 enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
               readiness:
                 enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
               startup:
                 enabled: true
+                custom: true
                 spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
                   failureThreshold: 30
                   periodSeconds: 5
             resources:


### PR DESCRIPTION
Switch rackpad's liveness/readiness/startup probes from app-template's default TCP checks to httpGet on `/api/health` — the endpoint rackpad's own compose healthcheck uses. Catches the app being up on the socket but unhealthy.

Validated with `kubectl kustomize`.