### PR TITLE
fix(o11y): disable non-actionable RecordingRulesNoData alert

### DIFF
--- a/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
+++ b/cluster/apps/o11y/victoria-metrics/app/helmrelease.yaml
@@ -78,6 +78,15 @@ spec:
     # below), so the matching default alert/recording rule groups can only ever
     # fire false KubeControllerManagerDown / KubeSchedulerDown alerts. Disable them.
     defaultRules:
+      # RecordingRulesNoData fires whenever a recording rule produces 0 samples
+      # for 30min. The upstream kube-prometheus rule count:up0
+      # (count(up == 0) ...) legitimately yields no samples whenever every scrape
+      # target is healthy, so this severity=info alert is non-actionable noise on
+      # the happy path. Disable the single meta-alert; the other vmalert health
+      # alerts (RecordingRulesError, RemoteWriteErrors, ...) stay enabled.
+      rules:
+        RecordingRulesNoData:
+          enabled: false
       groups:
         kubernetesSystemControllerManager:
           enabled: false   # KubeControllerManagerDown


### PR DESCRIPTION
## Problem

The vmalert `RecordingRulesNoData` meta-alert (severity: info) has been firing:

```
Recording rule "count:up0" from group "kube-prometheus-general.rules" produces 0 samples over the last 30min.
```

## Root cause

`RecordingRulesNoData` fires whenever any recording rule emits 0 samples for 30min. The upstream kube-prometheus rule is:

```promql
count:up0 = count(up == 0) without(instance,pod,node)
```

It counts *down* scrape targets. With every target healthy (`up == 0` matches nothing), `count()` returns an empty vector — so it produces no samples **by design**. Verified against the cluster: `count(up == 1)` = 54, `up == 0` = empty. Nothing is broken; the alert is non-actionable noise on the happy path.

## Fix

Disable the single meta-alert via `defaultRules.rules.RecordingRulesNoData.enabled: false`. This is surgical — the other vmalert health alerts (`RecordingRulesError`, `RemoteWriteErrors`, `ConfigurationReloadFailure`, ...) stay enabled. Follows the existing repo pattern of disabling false-positive default rules.

Verified against chart 0.85.7 that this knob drops the rule from the generated sync-job config.

## Rollout

Flux applies the HelmRelease → sync-job regenerates `vm-rule-vmalert` without the rule → vmalert reloads → the firing alert clears.