### PR TITLE
pin nasty-csi chart and image v0.0.10

### DIFF
--- a/cluster/apps/disk/nasty-csi/app/helmrelease.yaml
+++ b/cluster/apps/disk/nasty-csi/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.0.9
+    tag: 0.0.10
   url: oci://ghcr.io/nasty-project/charts/nasty-csi-driver
 ---
 # yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json


### PR DESCRIPTION
## Summary
- pin the nasty-csi OCI chart to `0.0.10`
- let chart `appVersion` update controller and node images to `v0.0.10`

## Verification
- released chart digest: `sha256:9734453303523b3343cd7b521ce31286cc3946c35982878d7c16a747194b46e3`
- released CSI image digest: `sha256:ff1f41533c54be56b4ef717a5b2518dd6b90b311426a1df9b66eca91fb320394`
- current HelmRelease values pass chart schema and strict lint
- controller and node images render as `ghcr.io/nasty-project/nasty-csi:v0.0.10`
- `kubectl kustomize` succeeds for the app tree
- current PVCs are bound and no VolumeSnapshots are in flight